### PR TITLE
Add initial content to the Prototypal-OO subtrack.

### DIFF
--- a/tracks/javascript/prototypal-oo/index.md
+++ b/tracks/javascript/prototypal-oo/index.md
@@ -1,0 +1,10 @@
+# Prototypal-OO
+
+* ["The Two Pillars of JavaScript Part 1"](https://medium.com/javascript-scene/the-two-pillars-of-javascript-ee6f3281e7f3) on Prototypal OO by [Eric Elliott](https://twitter.com/_ericelliott). #article
+* [*You Don't Know JS: this and Object Prototypes* - Chapter 5: Prototypes](https://github.com/getify/You-Dont-Know-JS/blob/master/this%20&%20object%20prototypes/ch5.md) by [Kyle Simpson](http://twitter.com/getify). #book
+* ["JS Objects: Inherited a Mess"](http://davidwalsh.name/javascript-objects) by [Kyle Simpson](http://twitter.com/getify). #article
+* ["Common Misconceptions About Inheritance in JavaScript"](https://medium.com/javascript-scene/common-misconceptions-about-inheritance-in-javascript-d5d9bab29b0a) by [Eric Elliott](https://twitter.com/_ericelliott). #article
+* ["Three Different Kinds of Prototypal OO"](http://ericleads.com/2013/02/fluent-javascript-three-different-kinds-of-prototypal-oo/) by [Eric Elliott](https://twitter.com/_ericelliott). #article
+* ["Classical Inheritance is Obsolete - How to Think in Prototypal OO"](https://vimeo.com/69255635) by [Eric Elliott](https://twitter.com/_ericelliott). #video
+* ["Prototypal Inheritance with Stamps"](http://chimera.labs.oreilly.com/books/1234000000262/ch03.html#prototypal_inheritance_with_stamps) by [Eric Elliott](https://twitter.com/_ericelliott). #article
+* ["Stampit Advanced Examples"](https://github.com/stampit-org/stampit/blob/master/ADVANCED_EXAMPLES.md) by [Vasyl Boroviak](https://github.com/koresar). #article


### PR DESCRIPTION
I've left off the Treaty of Orlando for the moment. While it provides support for the idea of prototypal OO, I'm not sure where it fits as a "learning resource" at this stage for your audience. Similarly, exploring other sources outside JavaScript (e.g. material related to Self) might distract from the overall goal. My gut says that you should be *very* selective about including material that isn't directly related to JavaScript. While useful, it might provide diminishing returns during the stage of learning your target audience is likely to be at.

Though I haven't included it in this commit, I feel as though there should be an intro paragraph at the top that clearly lays out the learning objectives for each subtrack.