### PR TITLE
Switch "Web Fundamentals" to "Fundamentals". Add initial content.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please read [Fighting Poverty with Code](https://medium.com/javascript-scene/fig
 We're trying to collect the best free training material in the world, so we have a higher standard than usual. Please read the [Contributing Guide](https://github.com/jshomes/learning-resources/blob/master/Contributing.md) before opening issues or pull requests.
 
 ## Contents
-1. [Web Fundamentals](tracks/fundamentals/index.md)
+1. [Fundamentals](tracks/fundamentals/index.md)
 1. [Developer Tools](tracks/dev-tools/index.md)
   1. [Git & GitHub](tracks/git-and-github/index.md)
   1. [Command Terminal](tracks/terminal/index.md)

--- a/fundamentals/index.md
+++ b/fundamentals/index.md
@@ -1,1 +1,6 @@
-# Web Fundamentals
+# Fundamentals
+
+[Computer Science 101](https://www.coursera.org/course/cs101) by [Stanford Online](http://online.stanford.edu). #course
+["What is Code?"](http://www.bloomberg.com/graphics/2015-paul-ford-what-is-code/) by [Paul Ford](https://twitter.com/ftrain). #article
+["How Does the Internet Work?"](https://www.youtube.com/watch?v=i5oe63pOhLI) by [Data Centers Canada](https://www.youtube.com/user/datacenterscanada1/). #video
+["20 Things I Learned About Browsers and the Web"](http://www.20thingsilearned.com) by [Google](https://www.google.com). #book


### PR DESCRIPTION
Felt like "Fundamentals" was more appropriate since the target audience will be new to more than just "web" concepts.